### PR TITLE
create_rhde_builder virt-install compatibility fix

### DIFF
--- a/roles/create_rhde_builder/tasks/start_rhde_builder_vm.yml
+++ b/roles/create_rhde_builder/tasks/start_rhde_builder_vm.yml
@@ -9,7 +9,7 @@
       --network bridge=virbr0,model=virtio
       --os-variant=rhel{{ rhde_builder_rhel_version }}
       --nographics --noautoconsole --import
-      --cloud-init root-ssh-key={{ rhde_builder_ssh_pubkey }},disable=off,clouduser-ssh-key={{ rhde_builder_ssh_pubkey }}
+      --cloud-init ssh-key={{ rhde_builder_ssh_pubkey }},disable=no
 
 - name: Wait for domain {{ rhde_builder_vm_name }} to be started
   become: true


### PR DESCRIPTION
Replace `--cloud-init root-ssh-key[…]` (>=v4.0) with `--cloud-init ssh-key[…]` (>=v3.0).

`ssh-key` is still available as an alias in versions with `root-ssh-key`.